### PR TITLE
adds timeout to mongoDB driver

### DIFF
--- a/lib/mongoFunctions.ts
+++ b/lib/mongoFunctions.ts
@@ -1,23 +1,25 @@
 import { SurveyDataset } from "@/types/SectionTypes";
 import { MongoClient, ObjectId } from "mongodb";
 const uri = process.env.MONGODB_URI || "";
-const client = new MongoClient(uri);
+const client = new MongoClient(uri, { socketTimeoutMS: 10000 });
 const coll = client.db("prod").collection("surveys");
 
 export async function createNewSurvey() {
   try {
-    const item = coll.insertOne({ sections: [] });
+    const item = await coll.insertOne({ sections: [] });
     // const result = await cursor.toArray();
-    return (await item).insertedId;
+    // client.close();
+    return item.insertedId;
   } catch (error) {
     // console.log(error);
   } finally {
   }
 }
 
-export function getSurvey(id: string) {
+export async function getSurvey(id: string) {
   try {
-    const surveyData = coll.findOne({ _id: new ObjectId(id) });
+    const surveyData = await coll.findOne({ _id: new ObjectId(id) });
+    // client.close();
     return surveyData;
   } catch (error) {}
 }
@@ -25,6 +27,7 @@ export async function updateSurvey(id: string, newData: SurveyDataset) {
   try {
     console.log("update");
     const res = await coll.replaceOne({ _id: new ObjectId(id) }, newData);
+    // client.close();
     console.log(res);
     //  const surveyData = coll.findOne({ _id: new ObjectId(id) });
     //  return surveyData;


### PR DESCRIPTION
Previously, the mongoDB driver did not have any timeout on the connections, and also didn't close them after each API request. over time this would cause Atlas to start blocking incoming connections.

I added a 10 second timeout, so the connections should now automatically close.